### PR TITLE
Fix crash when the file is uploaded successfully

### DIFF
--- a/nextcloud.js
+++ b/nextcloud.js
@@ -285,7 +285,8 @@ module.exports = function (RED) {
       client.putFileContents(directory + name, file, { format: 'binary' }, option)
         .then(function (contents) {
           console.log(contents)
-          node.send({ 'payload': JSON.parse(contents) })
+          // Response size is empty when the file is created successfully
+          node.send({ 'payload': {} })
         }, function () {
           node.error('Nextcloud:WebDAV -> send file went wrong.')
         })


### PR DESCRIPTION
This pull request fixes the crash that occurs when the file is uploaded successfully, as no content is returned from the server (so `JSON.parse()` fails).