### PR TITLE
Fix break when file is uploadded successfully in nextcloud.js 

### DIFF
--- a/nextcloud.js
+++ b/nextcloud.js
@@ -282,13 +282,29 @@ module.exports = function (RED) {
         option.agent = new https.Agent({ rejectUnauthorized: false })
       }
 
-      client.putFileContents(directory + name, file, { format: 'binary' }, option)
+      client.putFileContents(directory + name, file, { format: 'binary' })
         .then(function (contents) {
-          console.log(contents)
-          node.send({ 'payload': JSON.parse(contents) })
-        }, function () {
-          node.error('Nextcloud:WebDAV -> send file went wrong.')
+          if (contents && contents?.status === 204) {
+            payload = {
+              message: 'File uploaded successfully.',
+              statuscode: contents?.status,
+              url: contents?.url
+            };
+            node.send({ 'payload':  payload});
+          } else {
+            try {
+              // Trying to parse the response
+              node.send({ 'payload': JSON.parse(contents) });
+            } catch (e) {
+              // It is not valid json, parsing breaks
+              console.log('Response is not JSON:', contents);
+              node.send({ 'payload': contents });
+            }
+          }
         })
+        .catch(function () {
+          node.error('Nextcloud:WebDAV -> send file went wrong.');
+        });
     })
   }
   RED.nodes.registerType('nextcloud-webdav-in', NextcloudWebDavIn)


### PR DESCRIPTION
Fixed putFileContents()
- handle expected status code 204 No Content
- added returned message, file url and statuscode

This way you get an object in the payload:
```
{
  "message":"File uploaded successfully.",
  "statuscode":204,
  "url":"https://test.example.com/remote.php/webdav/DiscordScreenshots/test.jpg"
}
```
![image](https://github.com/user-attachments/assets/fea29433-df89-4b54-a752-92a2aad2c7ee)


## Root cause
The API returns invalid object, which cannot be parsed:
```
Response is not JSON: Response {
  size: 0,
  timeout: 0,
  [Symbol(Body internals)]: {
    body: PassThrough {
      _events: [Object],
      _readableState: [ReadableState],
      _writableState: [WritableState],
      allowHalfOpen: true,
      _maxListeners: undefined,
      _eventsCount: 2,
      [Symbol(shapeMode)]: true,
      [Symbol(kCapture)]: false,
      [Symbol(kCallback)]: null
    },
    disturbed: false,
    error: null
  },
  [Symbol(Response internals)]: {
    url: 'https://test.example.com/remote.php/webdav/DiscordScreenshots/test.jpg',
    status: 204,
    statusText: 'No Content',
    headers: Headers { [Symbol(map)]: [Object: null prototype] }
  }
}
```

So, code broke and node-red stopped running:
```
15 Mar 09:52:22 - [error] SyntaxError: Unexpected token 'o', "[object Response]" is not valid JSON
    at JSON.parse (<anonymous>)
    at C:\Users\koger\.node-red\node_modules\node-red-contrib-nextcloud\nextcloud.js:217:48
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```

## Related:
#16 is a pending PR, but it is just a workaround without file URL or status check.